### PR TITLE
Ticked #34  Bug: Cart resource has duplicate line items

### DIFF
--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -32,10 +32,10 @@ class Cart(ViewSet):
             open_order.customer = current_user
             open_order.save()
 
-        line_item = OrderProduct()
-        line_item.product = Product.objects.get(pk=request.data["product_id"])
-        line_item.order = open_order
-        line_item.save()
+        lineitem = OrderProduct()
+        lineitem.product = Product.objects.get(pk=request.data["product_id"])
+        lineitem.order = open_order
+        lineitem.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
@@ -54,11 +54,11 @@ class Cart(ViewSet):
         open_order = Order.objects.get(
             customer=current_user, payment_type=None)
 
-        line_item = OrderProduct.objects.filter(
+        lineitem = OrderProduct.objects.filter(
             product__id=pk,
             order=open_order
         )[0]
-        line_item.delete()
+        lineitem.delete()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
@@ -75,9 +75,9 @@ class Cart(ViewSet):
         @apiSuccess (200) {Object} payment_type Payment id use to complete order
         @apiSuccess (200) {String} customer URI for customer
         @apiSuccess (200) {Number} size Number of items in cart
-        @apiSuccess (200) {Object[]} line_items Line items in cart
-        @apiSuccess (200) {Number} line_items.id Line item id
-        @apiSuccess (200) {Object} line_items.product Product in cart
+        @apiSuccess (200) {Object[]} lineitems Line items in cart
+        @apiSuccess (200) {Number} lineitems.id Line item id
+        @apiSuccess (200) {Object} lineitems.product Product in cart
         @apiSuccessExample {json} Success
             {
                 "id": 2,

--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -32,10 +32,10 @@ class Cart(ViewSet):
             open_order.customer = current_user
             open_order.save()
 
-        lineitem = OrderProduct()
-        lineitem.product = Product.objects.get(pk=request.data["product_id"])
-        lineitem.order = open_order
-        lineitem.save()
+        line_item = OrderProduct()
+        line_item.product = Product.objects.get(pk=request.data["product_id"])
+        line_item.order = open_order
+        line_item.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
@@ -54,11 +54,11 @@ class Cart(ViewSet):
         open_order = Order.objects.get(
             customer=current_user, payment_type=None)
 
-        lineitem = OrderProduct.objects.filter(
+        line_item = OrderProduct.objects.filter(
             product__id=pk,
             order=open_order
         )[0]
-        lineitem.delete()
+        line_item.delete()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
@@ -75,9 +75,9 @@ class Cart(ViewSet):
         @apiSuccess (200) {Object} payment_type Payment id use to complete order
         @apiSuccess (200) {String} customer URI for customer
         @apiSuccess (200) {Number} size Number of items in cart
-        @apiSuccess (200) {Object[]} lineitems Line items in cart
-        @apiSuccess (200) {Number} lineitems.id Line item id
-        @apiSuccess (200) {Object} lineitems.product Product in cart
+        @apiSuccess (200) {Object[]} line_items Line items in cart
+        @apiSuccess (200) {Number} line_items.id Line item id
+        @apiSuccess (200) {Object} line_items.product Product in cart
         @apiSuccessExample {json} Success
             {
                 "id": 2,

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -184,7 +184,7 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
+                
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -190,7 +190,6 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
Removed line duplicating the lineitems as line_items.

## Changes

.bangaonapi/views/profile - Removed line that duplicated the lineitems in the cart output.

## Requests / Responses

**Request**

In order to manually test the server response, you can use the following:

GET `/profile/cart` Should display something similar to:

```json
{
    "id": 10,
    "url": "http://localhost:8000/orders/10",
    "created_date": "2018-11-03",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/4",
    "lineitems": [
        {
            "id": 2,
            "product": {
                "id": 3,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "Seoul",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        }
    ],
    "size": 1
}
**Response**

HTTP/1.1 200 OK


## Testing

Description of how to test code...

- [ ] Start the server
- [ ] If you do not have a login token, follow the procedures for obtaining one and adding it to Postman.
- [ ] In Postman create a GET request for http://localhost:8000/profile/cart
- [ ] The out put should look like the above and there should be no "line_item" field duplicating "lineitem"


## Related Issues

- Fixes #34