### PR TITLE
Cannot Remove Item From Cart Bug-Fix

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,6 +77,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
This PR solves the issue of being unable to delete the `lineitem` resource.

## Changes

- `/bangazonapi/views/lineitem.py` - Added functionality to remove the `lineitem` from the database.


## Request / Response Testing

- Throughout your testing, it is important that you use the same token in your **Authorization** header for all of your requests. It does not matter which one you use, but if your token is inconsistent, then you will get errant results.
- If you would like to undo any changes you've made to the database at any time, then you can run `./seed_data.sh` in the terminal to reset your database.

**Request**
First, make sure that the current user has some `lineitems` in their cart. You can do this by making the following request:

- GET `/profile/cart`

**Response**
This should return info about the user's cart. What we care about is the `lineitems` property. Make sure that there is at least one entry under the `lineitems` in the response. For example:

HTTP/1.1 200 OK

```json
{
    "id": 10,
    "url": "http://localhost:8000/orders/10",
    "created_date": "2018-11-03",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/4",
    "lineitems": [
        {
            "id": 2,
            "product": {
                "id": 3,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "Seoul",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        }
    ],
    "size": 1
}
```

**Request**
Next, use the corresponding `lineitem`'s `id` (see above) to verify that you are targeting the correct url. You can do this by making the following request:

- GET `/lineitems/n`
_(where `n` is equal to the `lineitem`'s `id`)_

**Response**
This should return the targeted `lineitem` resource. For example:

HTTP/1.1 200 OK

```json
{
    "id": 2,
    "url": "http://localhost:8000/lineitems/2",
    "order": "http://localhost:8000/orders/10",
    "product": "http://localhost:8000/products/3"
}
```

**Request**
Lastly, once you've verified that the `lineitem` exists, you need to verify that it can be deleted. You can do this by making the following request:

- DELETE `/lineitems/n`
_(where `n` is equal to the `lineitem`'s `id`)_

**Response**

HTTP/1.1 204 No Content

```json
{}
```

Once all steps are complete, you should find that the `lineitem` has been successfully deleted from the database. You can confirm this by using either of the above first and second requests.

## Related Issues

- Fixes [#29](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/issues/29)