### PR TITLE
Improper Payment Date Assignment Bug-Fix

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
This PR solves the issue of new payment types incorrectly being created with their `expiration_date` and `create_date` swapped.

## Changes

- `/bangazonapi/views/paymenttype.py`
    - Corrected `expiration_date` and `create_date` value assignments


## Request / Response Testing

- To test this code, make sure that you are in the most recent version of the `bugfix/payment-date` branch on your API-side.
- If you would like to undo any changes you've made to the database at any time during testing, then you can run `./seed_data.sh` in the terminal to reset your database.

### Request

- [x] Make a POST request to `/paymenttypes` with the following body (or something similar).

```json
{
  "merchant_name": "American Express",
  "account_number": "111-1111-1111",
  "expiration_date": "2025-12-31",
  "create_date": "2024-04-01"
}
```

### Response

- [x] Verify that the created item in the response has `expiration_date` and `create_date` values that match the values of your request. For example:

HTTP/1.1 201 Created

```json
{
  "id": 1,
  "url": "http://localhost:8000/paymenttypes/1",
  "merchant_name": "American Express",
  "account_number": "111-1111-1111",
  "expiration_date": "2025-12-31",
  "create_date": "2024-04-01"
}
```

## Final Testing

- [x] Lastly, run the following command in your terminal:
```shell
python3 manage.py test tests -v 1
```

- [x] There should be no failed tests in this output. Verify that the response looks something like this:
```
Found 6 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
......
----------------------------------------------------------------------
Ran 6 tests in 3.229s

OK
Destroying test database for alias 'default'...
```