### PR TITLE
Payment Type Deletion Integration Test

### DIFF
--- a/tests/payments.py
+++ b/tests/payments.py
@@ -22,7 +22,7 @@ class PaymentTests(APITestCase):
         """
         Ensure we can add a payment type for a customer.
         """
-        # Add product to order
+        # Add payment type
         url = "/paymenttypes"
         data = {
             "merchant_name": "American Express",
@@ -40,4 +40,30 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
-    # TODO: Delete payment type
+    def test_delete_payment_type(self):
+        """
+        Ensure we can delete a payment type for a customer.
+        """
+        # Add payment type
+        url = "/paymenttypes"
+        data = {
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
+            "expiration_date": "2025-12-31",
+            "create_date": datetime.date.today(),
+        }
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Delete payment type
+        url = f"/paymenttypes/{json_response["id"]}"
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Verify payment type was deleted
+        url = "/paymenttypes"
+        response = self.client.get(url)
+        json_response = json.loads(response.content)
+        self.assertEqual(len(json_response), 0)


### PR DESCRIPTION
This PR adds a new integration test to validate that you are able to delete a payment type.

## Changes

- `/tests/payments.py`
    - Added a `test_delete_payment_type` class

## Testing

To test this code, make sure that you are in the most recent version of the `test/delete-payment` branch on your API-side.
- [ ] Run the following command in your terminal:
```zsh
python3 manage.py test tests -v 1
```

- [ ] There should be a total of 7 tests in the output. Verify that none of these tests fail, or raise any errors. Your terminal output should look something like this:
```
Found 7 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.......
----------------------------------------------------------------------
Ran 7 tests in 1.234s

OK
Destroying test database for alias 'default'...
```
## Related Issues

- Completes ticket [#17](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/issues/17)