### PR TITLE
Product Deletion Integration Test

### DIFF
--- a/tests/product.py
+++ b/tests/product.py
@@ -95,6 +95,21 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 3)
 
-    # TODO: Delete product
+    def test_delete_product(self):
+        """
+        Ensure we can delete a product.
+        """
+        self.test_create_product()
+
+        url = "/products/1"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.delete(url, None, format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        url = "/products"
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 0)
 
     # TODO: Product can be rated. Assert average rating exists.


### PR DESCRIPTION
This PR adds a new integration test to validate that you are able to delete a product.

## Changes

- `/tests/product.py`
    - Added a `test_delete_product` class

## Testing

To test this code, make sure that you are in the most recent version of the `test/delete-product` branch on your API-side.
- [x] Run the following command in your terminal:
```zsh
python3 manage.py test tests -v 1
```

- [x] There should be a total of 9 tests in the output. Verify that none of these tests fail, or raise any errors. Your terminal output should look something like this:
```
Found 9 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
. . . . . . . . .
----------------------------------------------------------------------
Ran 9 tests in 1.234s

OK
Destroying test database for alias 'default'...
```
## Related Issues

- Completes ticket [#16](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/issues/16)