### PR TITLE
Rating a Product

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -6,26 +6,30 @@ from rest_framework.authtoken.views import obtain_auth_token
 from bangazonapi.models import *
 from bangazonapi.views import *
 
-# pylint: disable=invalid-name
-router = routers.DefaultRouter(trailing_slash=False)
-router.register(r'products', Products, 'product')
-router.register(r'productcategories', ProductCategories, 'productcategory')
-router.register(r'lineitems', LineItems, 'orderproduct')
-router.register(r'customers', Customers, 'customer')
-router.register(r'users', Users, 'user')
-router.register(r'orders', Orders, 'order')
-router.register(r'cart', Cart, 'cart')
-router.register(r'paymenttypes', Payments, 'payment')
-router.register(r'profile', Profile, 'profile')
 
+router = routers.DefaultRouter(trailing_slash=False)
+router.register(r"products", Products, "product")
+router.register(r"productcategories", ProductCategories, "productcategory")
+router.register(r"lineitems", LineItems, "orderproduct")
+router.register(r"customers", Customers, "customer")
+router.register(r"users", Users, "user")
+router.register(r"orders", Orders, "order")
+router.register(r"cart", Cart, "cart")
+router.register(r"paymenttypes", Payments, "payment")
+router.register(r"profile", Profile, "profile")
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
-    path('', include(router.urls)),
-    path('register', register_user),
-    path('login', login_user),
-    path('api-token-auth', obtain_auth_token),
-    path('api-auth', include('rest_framework.urls', namespace='rest_framework')),
+    path("", include(router.urls)),
+    path("register", register_user),
+    path("login", login_user),
+    path("api-token-auth", obtain_auth_token),
+    path("api-auth", include("rest_framework.urls", namespace="rest_framework")),
     path("reports/orders", order_report, name="order_report"),
+    path(
+        "products/<int:pk>/rate-product",
+        Products.as_view({"post": "rate_product"}),
+        name="product-rate",
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -343,7 +343,7 @@ class Products(ViewSet):
             rating = request.data.get("score")
         review = request.data.get("review", "")
 
-        # Check if the customer has already rated this product
+        # check if customer has already rated this product
         existing_rating = ProductRating.objects.filter(
             product=product, customer=customer
         ).first()
@@ -351,13 +351,13 @@ class Products(ViewSet):
         try:
 
             if existing_rating:
-                # Update the existing rating
+                # update existing rating
                 existing_rating.rating = rating
                 existing_rating.review = review
                 existing_rating.save()
                 serializer = RatingSerializer(existing_rating)
             else:
-                # Create a new rating
+                # create new rating
                 new_rating = ProductRating.objects.create(
                     product=product, customer=customer, rating=rating, review=review
                 )

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -349,6 +349,8 @@ class Products(ViewSet):
         ).first()
 
         try:
+            if (rating is not None) and ((rating < 1) or (rating > 5)):
+                raise IntegrityError("Rating must be within range 1-5")
 
             if existing_rating:
                 # update existing rating
@@ -365,4 +367,4 @@ class Products(ViewSet):
         except IntegrityError as ex:
             return Response({"message": ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -6,11 +6,12 @@ import base64
 from django.core.files.base import ContentFile
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseServerError
+from django.db import IntegrityError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
-from bangazonapi.models import Product, Customer, ProductCategory
+from bangazonapi.models import Product, Customer, ProductCategory, ProductRating
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.parsers import MultiPartParser, FormParser
 
@@ -34,6 +35,12 @@ class ProductSerializer(serializers.ModelSerializer):
             "can_be_rated",
         )
         depth = 1
+
+
+class RatingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ProductRating
+        fields = ("id", "customer", "product", "rating")
 
 
 class Products(ViewSet):
@@ -325,3 +332,37 @@ class Products(ViewSet):
             return Response(None, status=status.HTTP_204_NO_CONTENT)
 
         return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @action(methods=["post"], detail=True)
+    def rate_product(self, request, pk=None):
+        """Rate a product"""
+        product = Product.objects.get(pk=pk)
+        customer = Customer.objects.get(user=request.auth.user)
+        rating = request.data.get("rating")
+        if not rating:
+            rating = request.data.get("score")
+        review = request.data.get("review", "")
+
+        # Check if the customer has already rated this product
+        existing_rating = ProductRating.objects.filter(
+            product=product, customer=customer
+        ).first()
+
+        try:
+
+            if existing_rating:
+                # Update the existing rating
+                existing_rating.rating = rating
+                existing_rating.review = review
+                existing_rating.save()
+                serializer = RatingSerializer(existing_rating)
+            else:
+                # Create a new rating
+                new_rating = ProductRating.objects.create(
+                    product=product, customer=customer, rating=rating, review=review
+                )
+                serializer = RatingSerializer(new_rating)
+        except IntegrityError as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
This PR adds the functionality for users to rate a given product.

## Changes

- `/bangazonapi/views/product.py`
    - added a `RatingSerializer`
    - added a `rate_product` viewset for handling POST requests for new ratings
- `/bangazon/urls.py`
    - added a route handler for `/products/n/rate-product` (to match client-side expectations)


## Request / Response Testing

- To test this code, make sure that you are in the most recent version of the `feature/rating-products` branch on your API-side.
- If you would like to undo any changes you've made to the database at any time during testing, then you can run `./seed_data.sh` in the terminal to reset your database.

### Request

- [ ] Make a POST request to `/products/n/rate-product` with the following body (or something similar).

Notes about the request url: 
- "`n`" can be equal to any `product`'s `id` that is in the database, but it is recommended you do ***not*** use "`50`", due to there being some preloaded fixtures for that item.

```json
{
  "score": 1,
  "review": "Lorem ipsum..."
}
```

Notes about the request body: 
- The "`score`" property can be equal to any integer between 1-5
- The "`review`" property is not strictly necessary
- The "`score`" property may be replaced by the "`rating`" property, and all will still function correctly. This example request body is structured using `score` to mirror the current behavior of the client-side. Also note that the response will return with a "`rating`" property, regardless of which of these is used.

### Response(s)

- [x] If the new item was created successfully, it should return something like this:

HTTP/1.1 201 Created

```json
{
  "id": 1,
  "customer": 1,
  "product": 1,
  "rating": 1
}
```

- [x] If you did not provide a `rating`, then you should get this response:

HTTP/1.1 400 Bad Request

```json
{ "message": "NOT NULL constraint failed: bangazonapi_productrating.rating" }
```

- [x] And lastly, if you provided a `rating` that was out of the range of 1-5, then you should get this response:

HTTP/1.1 400 Bad Request

```json
{ "message": "Rating must be within range 1-5" }
```

One more thing you should know during your testing, is that this new viewset functions so that there can only be one instance of each `productrating` for each combination of product and user. What this means is, if you make a POST request for a new `rating` to a product that has already been rated by the current user (defined by the **Authorization** header), then it will simply function as a PUT request, and replace the old `rating` for that product. This is intentional, and will help prevent the creation of duplicate data.

## Related Issues

- Ticket [#15](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/issues/15)