### PR TITLE
Product Rating Integration Test

### DIFF
--- a/bangazonapi/models/order.py
+++ b/bangazonapi/models/order.py
@@ -8,4 +8,3 @@ class Order(models.Model):
     customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING,)
     payment_type = models.ForeignKey(Payment, on_delete=models.DO_NOTHING, null=True)
     created_date = models.DateField(default="0000-00-00",)
-    lineitems = models.ManyToManyField('bangazonapi.Product', through='bangazonapi.OrderProduct', related_name='orders')

--- a/bangazonapi/models/orderproduct.py
+++ b/bangazonapi/models/orderproduct.py
@@ -5,7 +5,7 @@ class OrderProduct(models.Model):
 
     order = models.ForeignKey("Order",
                               on_delete=models.DO_NOTHING,
-                              related_name="order_products")
+                              related_name="lineitems")
 
     product = models.ForeignKey("Product",
                                 on_delete=models.DO_NOTHING,

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -150,23 +150,31 @@ class Orders(ViewSet):
         json_orders = OrderSerializer(orders, many=True, context={"request": request})
 
         return Response(json_orders.data)
-    
-    
+
+
 def order_report(request):
-    if request.GET.get('status') == 'incomplete':
-        orders = Order.objects.filter(payment_type__isnull=True).select_related('customer__user')
+    if request.GET.get("status") == "incomplete":
+        orders = Order.objects.filter(payment_type__isnull=True).select_related(
+            "customer__user"
+        )
         order_data = []
         for order in orders:
-            total_cost = round(sum([item.product.price for item in order.order_products.all()]), 2)
-            customer_name = f"{order.customer.user.first_name} {order.customer.user.last_name}"
-            order_data.append({
-                'id': order.id,
-                'customer_name': customer_name,
-                'total_cost': total_cost,
-            })
+            total_cost = round(
+                sum([item.product.price for item in order.lineitems.all()]), 2
+            )
+            customer_name = (
+                f"{order.customer.user.first_name} {order.customer.user.last_name}"
+            )
+            order_data.append(
+                {
+                    "id": order.id,
+                    "customer_name": customer_name,
+                    "total_cost": total_cost,
+                }
+            )
         context = {
-            'orders': order_data,
+            "orders": order_data,
         }
-        return render(request, 'orders_report.html', context)
+        return render(request, "orders_report.html", context)
 
-    return render(request, 'orders_report.html', {'orders': []})
+    return render(request, "orders_report.html", {"orders": []})

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -40,7 +40,7 @@ class ProductSerializer(serializers.ModelSerializer):
 class RatingSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProductRating
-        fields = ("id", "customer", "product", "rating")
+        fields = ("id", "customer", "product", "rating", "review")
 
 
 class Products(ViewSet):

--- a/tests/order.py
+++ b/tests/order.py
@@ -162,4 +162,3 @@ class OrderTests(APITestCase):
         json_response = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response["lineitems"]), 1)
-

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -58,7 +58,7 @@ class PaymentTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Delete payment type
-        url = f"/paymenttypes/{json_response["id"]}"
+        url = f"/paymenttypes/{json_response['id']}"
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 

--- a/tests/product.py
+++ b/tests/product.py
@@ -10,18 +10,25 @@ class ProductTests(APITestCase):
         Create a new account and create sample category
         """
         url = "/register"
-        data = {"username": "steve", "password": "Admin8*", "email": "steve@stevebrownlee.com",
-                "address": "100 Infinity Way", "phone_number": "555-1212", "first_name": "Steve", "last_name": "Brownlee"}
-        response = self.client.post(url, data, format='json')
+        data = {
+            "username": "steve",
+            "password": "Admin8*",
+            "email": "steve@stevebrownlee.com",
+            "address": "100 Infinity Way",
+            "phone_number": "555-1212",
+            "first_name": "Steve",
+            "last_name": "Brownlee",
+        }
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
         self.token = json_response["token"]
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         url = "/productcategories"
         data = {"name": "Sporting Goods"}
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
 
-        response = self.client.post(url, data, format='json')
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -38,10 +45,10 @@ class ProductTests(APITestCase):
             "quantity": 60,
             "description": "It flies high",
             "category_id": 1,
-            "location": "Pittsburgh"
+            "location": "Pittsburgh",
         }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.post(url, data, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -65,13 +72,13 @@ class ProductTests(APITestCase):
             "description": "It flies very high",
             "category_id": 1,
             "created_date": datetime.date.today(),
-            "location": "Pittsburgh"
+            "location": "Pittsburgh",
         }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.put(url, data, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.put(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        response = self.client.get(url, data, format='json')
+        response = self.client.get(url, data, format="json")
         json_response = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json_response["name"], "Kite")
@@ -90,7 +97,7 @@ class ProductTests(APITestCase):
 
         url = "/products"
 
-        response = self.client.get(url, None, format='json')
+        response = self.client.get(url, None, format="json")
         json_response = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 3)
@@ -112,4 +119,26 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 0)
 
-    # TODO: Product can be rated. Assert average rating exists.
+    def test_rate_product(self):
+        """
+        Ensure we can rate a product.
+        """
+        # create product
+        self.test_create_product()
+
+        # rate the product
+        url = "/products/1/rate-product"
+        data = {"rating": 4, "review": "This kite is amazing!"}
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        json_response = json.loads(response.content)
+        self.assertEqual(json_response["rating"], 4)
+        self.assertEqual(json_response["review"], "This kite is amazing!")
+
+        # verify average rating
+        url = "/products/1"
+        response = self.client.get(url, format="json")
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("average_rating", json_response)
+        self.assertEqual(json_response["average_rating"], 4)


### PR DESCRIPTION
This PR adds a new integration test to validate that you are able to rate a product.

## Changes

- `/tests/product.py`
    - Added a `test_rate_product` class.
- `/bangazonapi/views/product.py`
    - Added "`review`" property to `RatingSerializer`.

### Unrelated Changes
- `/bangazonapi/views/order.py`, `/bangazonapi/models/orderproduct.py`, `/bangazonapi/models/order.py`
    - Fixed an issue found by @Luke-M-Williams that caused the `lineitems` property on an order to be inaccessible through the `Orders` table. The previous solution (_changing one of the `lineitems` to be `order_products`_) caused 4 of the integration tests to fail. Because of this, I have used a different solution to ensure that the `order_report` still functions correctly, but also the tests still pass.

## Testing

To test this code, make sure that you are in the most recent version of the `test/rating-products` branch on your API-side.
- [ ] Run the following command in your terminal:
```zsh
python3 manage.py test tests -v 1
```

- [ ] There should be a total of 11 tests in the output. Verify that none of these tests fail, or raise any errors. Your terminal output should look something like this:
```
Found 11 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
. . . . . . . . . . .
----------------------------------------------------------------------
Ran 11 tests in 1.234s

OK
Destroying test database for alias 'default'...
```
## Related Issues

- Completes ticket [#15](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/issues/15)
