### PR TITLE
Product Ratings Inclusion

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -16,8 +16,16 @@ from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.parsers import MultiPartParser, FormParser
 
 
+class RatingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ProductRating
+        fields = ("id", "customer", "product", "rating", "review")
+
+
 class ProductSerializer(serializers.ModelSerializer):
     """JSON serializer for products"""
+
+    ratings = RatingSerializer(many=True, read_only=True)
 
     class Meta:
         model = Product
@@ -32,15 +40,9 @@ class ProductSerializer(serializers.ModelSerializer):
             "location",
             "image_path",
             "average_rating",
-            "can_be_rated",
+            "ratings",
         )
         depth = 1
-
-
-class RatingSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = ProductRating
-        fields = ("id", "customer", "product", "rating", "review")
 
 
 class Products(ViewSet):


### PR DESCRIPTION
This PR adds the functionality that making a GET request for a `product` now includes the given `product`'s `ratings`.

## Changes

- `/bangazonapi/views/product.py`
    - added `ratings` property to `ProductSerializer`

## Request / Response Testing

- To test this code, make sure that you are in the most recent version of the `feature/rating-on-product` branch on your API-side.
- If you would like to undo any changes you've made to the database at any time during testing, then you can run `./seed_data.sh` in the terminal to reset your database (it is recommended to do this once before testing).

### Request

- [x] Make a GET request to `/products/n`.

Note that  "`n`" can be equal to any `product`'s `id`. For the following example, I have used `/products/50`, because there are currently 4 preloaded ratings for this product.

### Response

- [x] Verify that the `product` in the response contains a `ratings` property. For example:

HTTP/1.1 200 OK

```json
{
  "id": 50,
  "name": "Golf",
  "price": 653.59,
  "number_sold": 2,
  "description": "1994 Volkswagen",
  "quantity": 4,
  "created_date": "2019-07-10",
  "location": "Berlin",
  "image_path": "http://localhost:8000/media/products/vehicle.png",
  "average_rating": 3.25,
  "ratings": [
    {
      "id": 1,
      "customer": 4,
      "product": 50,
      "rating": 4,
      "review": "Lorem ipsum dolor sit amet consectetur, adipiscing elit sem morbi."
    },
    {
      "id": 2,
      "customer": 5,
      "product": 50,
      "rating": 3,
      "review": "Lorem ipsum dolor sit, amet consectetur adipiscing elit, natoque faucibus."
    },
    {
      "id": 3,
      "customer": 6,
      "product": 50,
      "rating": 5,
      "review": "Lorem ipsum dolor sit amet consectetur, adipiscing elit turpis ornare."
    },
    {
      "id": 4,
      "customer": 7,
      "product": 50,
      "rating": 1,
      "review": "Lorem ipsum dolor sit, amet consectetur adipiscing elit, donec sociis."
    }
  ]
}

```
