### PR TITLE
Payment Creation Implementation

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -49,12 +49,6 @@ class Payments(ViewSet):
             Response -- JSON serialized payment instance
         """
 
-        """
-        {
-            "acctNumber": "1234123412341234",
-            "merchant": "Bruh"
-        }
-        """
         try:
             new_payment = Payment()
 

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -1,14 +1,13 @@
 """View module for handling requests about customer payment types"""
 
+from datetime import datetime
+from django.db.utils import IntegrityError
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
 from bangazonapi.models import Payment, Customer
-from django.db.utils import IntegrityError
-from django.core.exceptions import ValidationError
-from datetime import datetime
 
 
 class PaymentSerializer(serializers.HyperlinkedModelSerializer):
@@ -76,11 +75,6 @@ class Payments(ViewSet):
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         except IntegrityError as ex:
             return Response({"message": ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
-        except ValidationError:
-            return Response(
-                {"message": "Payment must include a valid expiration date"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
 
     def retrieve(self, request, pk=None):
         """Handle GET requests for single payment type

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer payment types"""
+
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
@@ -13,14 +14,27 @@ class PaymentSerializer(serializers.HyperlinkedModelSerializer):
     Arguments:
         serializers
     """
+
+    obscured_num = serializers.SerializerMethodField()
+
     class Meta:
         model = Payment
         url = serializers.HyperlinkedIdentityField(
-            view_name='payment',
-            lookup_field='id'
+            view_name="payment", lookup_field="id"
         )
-        fields = ('id', 'url', 'merchant_name', 'account_number',
-                  'expiration_date', 'create_date')
+        fields = (
+            "id",
+            "url",
+            "merchant_name",
+            "account_number",
+            "expiration_date",
+            "create_date",
+            "obscured_num",
+        )
+
+    def get_obscured_num(self, obj):
+        account_num = obj.account_number
+        return f"{'*' * (len(account_num) - 4)}{account_num[-4:]}"
 
 
 class Payments(ViewSet):
@@ -40,8 +54,7 @@ class Payments(ViewSet):
         new_payment.customer = customer
         new_payment.save()
 
-        serializer = PaymentSerializer(
-            new_payment, context={'request': request})
+        serializer = PaymentSerializer(new_payment, context={"request": request})
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
@@ -53,8 +66,7 @@ class Payments(ViewSet):
         """
         try:
             payment_type = Payment.objects.get(pk=pk)
-            serializer = PaymentSerializer(
-                payment_type, context={'request': request})
+            serializer = PaymentSerializer(payment_type, context={"request": request})
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
@@ -72,15 +84,18 @@ class Payments(ViewSet):
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         except Payment.DoesNotExist as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
         except Exception as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
         customer = Customer.objects.get(user=request.auth.user)
         payment_types = Payment.objects.filter(customer=customer)
         serializer = PaymentSerializer(
-            payment_types, many=True, context={'request': request})
+            payment_types, many=True, context={"request": request}
+        )
         return Response(serializer.data)

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -6,6 +6,9 @@ from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
 from bangazonapi.models import Payment, Customer
+from django.db.utils import IntegrityError
+from django.core.exceptions import ValidationError
+from datetime import datetime
 
 
 class PaymentSerializer(serializers.HyperlinkedModelSerializer):
@@ -45,18 +48,47 @@ class Payments(ViewSet):
         Returns:
             Response -- JSON serialized payment instance
         """
-        new_payment = Payment()
-        new_payment.merchant_name = request.data["merchant_name"]
-        new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["expiration_date"]
-        new_payment.create_date = request.data["create_date"]
-        customer = Customer.objects.get(user=request.auth.user)
-        new_payment.customer = customer
-        new_payment.save()
 
-        serializer = PaymentSerializer(new_payment, context={"request": request})
+        """
+        {
+            "acctNumber": "1234123412341234",
+            "merchant": "Bruh"
+        }
+        """
+        try:
+            new_payment = Payment()
 
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+            merchant_name = request.data.get("merchant_name")
+            if not merchant_name:
+                merchant_name = request.data.get("merchant")
+
+            account_number = request.data.get("account_number")
+            if not account_number:
+                account_number = request.data.get("acctNumber")
+
+            customer = Customer.objects.get(user=request.auth.user)
+
+            new_payment.merchant_name = merchant_name
+            new_payment.account_number = account_number
+            new_payment.expiration_date = request.data.get(
+                "expiration_date", "0000-00-00"
+            )
+            new_payment.create_date = request.data.get(
+                "create_date", datetime.now().date()
+            )
+            new_payment.customer = customer
+            new_payment.save()
+
+            serializer = PaymentSerializer(new_payment, context={"request": request})
+
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        except IntegrityError as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+        except ValidationError:
+            return Response(
+                {"message": "Payment must include a valid expiration date"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
     def retrieve(self, request, pk=None):
         """Handle GET requests for single payment type

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -64,9 +64,7 @@ class Payments(ViewSet):
 
             new_payment.merchant_name = merchant_name
             new_payment.account_number = account_number
-            new_payment.expiration_date = request.data.get(
-                "expiration_date", "0000-00-00"
-            )
+            new_payment.expiration_date = request.data.get("expiration_date")
             new_payment.create_date = request.data.get(
                 "create_date", datetime.now().date()
             )


### PR DESCRIPTION
This PR solves three issues:
- creating a payment type with "`merchant`" is now possible
- creating a payment type with "`acctNumber`" is now possible
- retrieving a payment type now includes an "`obscured_num`" property

## Changes

- `/bangazonapi/views/paymenttype.py`
  - added an `obscured_num` field to the `PaymentSerializer`
  - added an optional check for the `merchant` property, if a `merchant_name` was not provided*
  - added an optional check for the `acctNumber ` property, if an `account_number` was not provided*
  - added an `IntegrityError` catch for when the client fails to provide all information
  - various formatting changes

#### *To match client-side expectations

## Request / Response Testing

- To test this code, make sure that you are in the most recent version of the `bugfix/invalid-payment` branch on your API-side.
- If you would like to undo any changes you've made to the database at any time during testing, then you can run `./seed_data.sh` in the terminal to reset your database (it is recommended to do this once before testing).

### Request

- [x] Make a POST request to [`/paymenttypes`](http://localhost:8000/paymenttypes) with the following request body (or something similar):

```json
{
  "merchant": "Bruh",
  "acctNumber": "1234123412341234",
  "expiration_date": "2025-12-31"
}
```

### Response

- [x] If the new payment type was created successfully, it should return something like this:

HTTP/1.1 201 Created

```json
{
  "id": 1,
  "url": "http://localhost:8000/paymenttypes/1",
  "merchant_name": "Bruh",
  "account_number": "1234123412341234",
  "expiration_date": "2025-12-31",
  "create_date": "2024-04-12",
  "obscured_num": "************1234"
}
```

- [x] Verify that the response body includes an `obscured_num` property.
