### PR TITLE
Feature: List Stores

### DIFF
--- a/bangazonapi/fixtures/stores.json
+++ b/bangazonapi/fixtures/stores.json
@@ -3,7 +3,7 @@
     "model": "bangazonapi.store",
     "pk": 1,
     "fields": {
-      "customer_id": 5,
+      "seller": 5,
       "name": "Tech Emporium",
       "description": "Your one-stop shop for all things tech! Find the latest gadgets, accessories, and more."
     }
@@ -12,7 +12,7 @@
     "model": "bangazonapi.store",
     "pk": 2,
     "fields": {
-      "customer_id": 6,
+      "seller": 6,
       "name": "Fashion Haven",
       "description": "Discover the trendiest clothing, shoes, and accessories here. Stay stylish all year round!"
     }
@@ -21,7 +21,7 @@
     "model": "bangazonapi.store",
     "pk": 3,
     "fields": {
-      "customer_id": 7,
+      "seller": 7,
       "name": "Home Essentials",
       "description": "Transform your living space with our selection of home decor, furniture, and household essentials."
     }
@@ -30,7 +30,7 @@
     "model": "bangazonapi.store",
     "pk": 4,
     "fields": {
-      "customer_id": 5,
+      "seller": 5,
       "name": "Fitness Zone",
       "description": "Get fit and stay healthy with our range of fitness equipment, supplements, and workout gear."
     }

--- a/bangazonapi/models/store.py
+++ b/bangazonapi/models/store.py
@@ -5,7 +5,7 @@ from .customer import Customer
 
 class Store(models.Model):
 
-    customer = models.ForeignKey(
+    seller = models.ForeignKey(
         Customer, on_delete=models.CASCADE, related_name="stores"
     )
     name = models.CharField(max_length=20)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -48,6 +48,7 @@ class ProductSerializer(serializers.ModelSerializer):
             "location",
             "image_path",
             "average_rating",
+            "customer_id",
             "ratings",
         )
         depth = 1
@@ -288,6 +289,7 @@ class Products(ViewSet):
                     "location": "Pittsburgh",
                     "image_path": null,
                     "average_rating": 0,
+                    "customer_id": 5,
                     "category": {
                         "url": "http://localhost:8000/productcategories/6",
                         "name": "Games/Toys"


### PR DESCRIPTION
When on Stores page, list of store name, desc, owner, and total quantity of products for sale appear as well as all of the products.

Addresses /NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/#1

## Changes

- stores.json: changing customer_id to seller
- models/store.py: changing customer to seller
- views/store.py: added new serializer to access seller first and last name
    - added list method to list all stores
- views/product.py: add customer id to serializer to access the attribute

## Requests / Responses

You can test this in Postman using http://localhost:8000/stores

**Request**

GET `/stores` Lists all stores

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 1,
        "seller": {
            "id": 5,
            "first_name": "Joe",
            "last_name": "Shepherd"
        },
        "name": "Tech Emporium",
        "description": "Your one-stop shop for all things tech! Find the latest gadgets, accessories, and more."
    },
    {
        "id": 2,
        "seller": {
            "id": 6,
            "first_name": "Jisie",
            "last_name": "David"
        },
        "name": "Fashion Haven",
        "description": "Discover the trendiest clothing, shoes, and accessories here. Stay stylish all year round!"
    }
]
```

## Testing

- [x] Run debugger
- [x] Make sure client side is running
- [x] Navigate to Stores page
- [x] Confirm that all stores show up with store name, owner, and description.

![Screenshot 2024-04-12 at 2 12 25 PM](https://github.com/NSS-Day-Cohort-68/bangazon-api-bangazon-team-1-api/assets/149907329/37313cbe-1e2e-4295-9af7-3ec1c6b63b36)
